### PR TITLE
cache support for GetMfaTokensPrivacyIDEA

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,20 @@ Use this filter to read user mfa tokens from PrivacyIDEA server to state attribu
         'tokens_type' => [
             'TOTP',
             'WebAuthn',
-            ],
+        ],
         'user_attribute' => 'eduPersonPrincipalName',
         'token_type_attr' => 'type',
-        ],
     ],
+],
+```
+
+To enable caching of the privacyIDEA auth token, add:
+
+```php
+    // ...
+        'enable_cache' => true, // defaults to false
+        'cache_expiration_seconds' => 30 * 60, // defaults to 55 minutes
+    // ...
 ```
 
 ## Use (configure as auth proc filter)

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,9 @@
   "config": {
     "platform": {
       "php": "7.4"
+    },
+    "allow-plugins": {
+      "simplesamlphp/composer-module-installer": true
     }
   },
   "license": "BSD-2-Clause",
@@ -24,7 +27,8 @@
     "simplesamlphp/composer-module-installer": "~1.0",
     "ext-json": "*",
     "mobiledetect/mobiledetectlib": "^2.8",
-    "ext-curl": "*"
+    "ext-curl": "*",
+    "simplesamlphp/simplesamlphp": "^1.19"
   },
   "require-dev": {
     "symplify/easy-coding-standard": "^10.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f460c618dcdc874b518e19b54ec40dff",
+    "content-hash": "682a5e9f1e6c9c0cadb8409e2f3efd19",
     "packages": [
         {
             "name": "brick/math",
@@ -996,12 +996,12 @@
             },
             "type": "project",
             "autoload": {
-                "psr-4": {
-                    "SimpleSAML\\": "lib/SimpleSAML"
-                },
                 "files": [
                     "lib/_autoload_modules.php"
-                ]
+                ],
+                "psr-4": {
+                    "SimpleSAML\\": "lib/SimpleSAML"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [


### PR DESCRIPTION
new optional config options `enable_cache` and `cache_expiration_seconds` to enable storing PI auth token in the current `\SimpleSAML\Store` and reduce load on PI API