### PR TITLE
docs: fix documentation of proxy_mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,10 +140,11 @@ already. You just need to set the `proxy_mode` configuration option to `true`:
 ```php
 53 => [
     'class' => 'authswitcher:SwitchAuth',
-    'proxy_mode' => true,
-    'configs' => [
+    'config' => [
+        'proxy_mode' => true,
         // ...
     ],
+    //...
 ]
 ```
 


### PR DESCRIPTION
option `proxy_mode` is now nested in the `config` array