### PR TITLE
fix: ignore mfaEnforced when user has no MFA tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ already. You just need to set the `proxy_mode` configuration option to `true`:
 
 If a user should only use MFA, set `mfaEnforced` user attribute to a non-empty value. You can fill this attribute any way you like, for example from LDAP or from database.
 
+If the user has no MFA tokens and `mfaEnforced` is non-empty, it is ignored (to prevent lock-outs).
+
 When the attribute is not empty, single factor authentication is not considered. Therefore, when an SP requests `SFA` or `PasswordProtectedTransport` specifically, the authentication will fail.
 
 ## Add additional attributes when MFA is performed

--- a/lib/Auth/Process/SwitchAuth.php
+++ b/lib/Auth/Process/SwitchAuth.php
@@ -214,7 +214,7 @@ class SwitchAuth extends \SimpleSAML\Auth\ProcessingFilter
                 }
             }
         }
-        if (empty($state['Attributes']['mfaEnforced'])) {
+        if (empty($state['Attributes']['mfaEnforced']) || empty($result)) {
             $result[] = AuthSwitcher::SFA;
         }
 


### PR DESCRIPTION
prevent lock-outs when user removes or revokes all tokens

BREAKING CHANGE: mfaEnforced is ignored for users without MFA tokens