### PR TITLE
fix enforced MFA

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ If the user has no MFA tokens and `mfaEnforced` is non-empty, it is ignored (to 
 
 When the attribute is not empty, multi-factor authentication is always performed. Because it is assumed that the first factor is always password based, when a SP requests `https://refeds.org/profile/sfa` or `PasswordProtectedTransport` specifically, MFA is performed but one of the requested authentication contexts is returned.
 
+When used with proxy mode, MFA is not forced if it was already done at upstream IdP.
+
 ## Add additional attributes when MFA is performed
 
 To add attributes only if MFA was performed, you can use a filter called `AddAdditionalAttributesAfterMfa`.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@ with [PrivacyIDEA](https://github.com/xpavlic/simplesamlphp-module-privacyidea)
 and [TOTP](https://gitlab.ics.muni.cz/perun/proxyaai/simplesamlphp/simplesamlphp-module-totp) [authentication processing filters](https://simplesamlphp.org/docs/stable/simplesamlphp-authproc)
 and honoring + setting `AuthnContextClassRef`, both for IdP and proxy.
 
+It is assumed that the auth source is password based, then secondary authentication (based on a token) is performed via this module.
+The following authentication contexts are supported for password (single factor) authentication:
+
+- `urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport`
+- [REFEDS SFA profile](https://refeds.org/profile/sfa)
+
+The following authentication contexts are supported for multi-factor authentication:
+
+- [REFEDS MFA profile](https://refeds.org/profile/mfa)
+- `http://schemas.microsoft.com/claims/multipleauthn`
+
 ## Install
 
 You have to install this module using Composer together with SimpleSAMLphp so that dependencies are installed as well.
@@ -156,7 +167,7 @@ If a user should only use MFA, set `mfaEnforced` user attribute to a non-empty v
 
 If the user has no MFA tokens and `mfaEnforced` is non-empty, it is ignored (to prevent lock-outs).
 
-When the attribute is not empty, single factor authentication is not considered. Therefore, when an SP requests `SFA` or `PasswordProtectedTransport` specifically, the authentication will fail.
+When the attribute is not empty, multi-factor authentication is always performed. Because it is assumed that the first factor is always password based, when a SP requests `https://refeds.org/profile/sfa` or `PasswordProtectedTransport` specifically, MFA is performed but one of the requested authentication contexts is returned.
 
 ## Add additional attributes when MFA is performed
 

--- a/lib/Auth/Process/SwitchAuth.php
+++ b/lib/Auth/Process/SwitchAuth.php
@@ -130,11 +130,12 @@ class SwitchAuth extends \SimpleSAML\Auth\ProcessingFilter
             throw new Exception(self::DEBUG_PREFIX . 'MFA is preferred but connection to privacyidea failed.');
         }
 
-        $performMFA = ($this->mfa_enforced && AuthnContextHelper::MFAin($usersCapabilities)) || (
-            AuthnContextHelper::MFAin($usersCapabilities)
-                && AuthnContextHelper::isMFAprefered($state[AuthSwitcher::SUPPORTED_REQUESTED_CONTEXTS])
-                && !AuthnContextHelper::MFAin([$upstreamContext])
-        ); // switch to MFA if preferred and not already done if we handle the proxy mode
+        // switch to MFA if enforced or preferred but not already done if we handle the proxy mode
+        $performMFA = AuthnContextHelper::MFAin($usersCapabilities) && !AuthnContextHelper::MFAin([
+            $upstreamContext,
+        ]) && ($this->mfa_enforced || AuthnContextHelper::isMFAprefered(
+            $state[AuthSwitcher::SUPPORTED_REQUESTED_CONTEXTS]
+        ));
 
         $maxUserCapability = '';
         if (in_array(AuthSwitcher::MFA, $usersCapabilities, true)) {

--- a/lib/Auth/Process/SwitchAuth.php
+++ b/lib/Auth/Process/SwitchAuth.php
@@ -56,6 +56,11 @@ class SwitchAuth extends \SimpleSAML\Auth\ProcessingFilter
     private $max_auth = 'https://id.muni.cz/profile/maxAuth';
 
     /**
+     * Whether MFA is enforced for the current user.
+     */
+    private $mfa_enforced;
+
+    /**
      * @override
      *
      * @param mixed $config
@@ -82,6 +87,7 @@ class SwitchAuth extends \SimpleSAML\Auth\ProcessingFilter
             $this->max_user_capability_attr
         );
         $this->max_auth = $config->getString('max_auth', $this->max_auth);
+        $this->mfa_enforced = !empty($state['Attributes']['mfaEnforced']);
     }
 
     /**
@@ -109,7 +115,8 @@ class SwitchAuth extends \SimpleSAML\Auth\ProcessingFilter
         $state[AuthSwitcher::SUPPORTED_REQUESTED_CONTEXTS] = AuthnContextHelper::getSupportedRequestedContexts(
             $usersCapabilities,
             $state,
-            $upstreamContext
+            $upstreamContext,
+            $this->mfa_enforced
         );
 
         self::info('supported requested contexts: ' . json_encode($state[AuthSwitcher::SUPPORTED_REQUESTED_CONTEXTS]));
@@ -123,7 +130,7 @@ class SwitchAuth extends \SimpleSAML\Auth\ProcessingFilter
             throw new Exception(self::DEBUG_PREFIX . 'MFA is preferred but connection to privacyidea failed.');
         }
 
-        $performMFA = !AuthnContextHelper::SFAin($usersCapabilities) || (
+        $performMFA = ($this->mfa_enforced && AuthnContextHelper::MFAin($usersCapabilities)) || (
             AuthnContextHelper::MFAin($usersCapabilities)
                 && AuthnContextHelper::isMFAprefered($state[AuthSwitcher::SUPPORTED_REQUESTED_CONTEXTS])
                 && !AuthnContextHelper::MFAin([$upstreamContext])
@@ -150,13 +157,14 @@ class SwitchAuth extends \SimpleSAML\Auth\ProcessingFilter
     {
         $mfaPerformed = Utils::wasMFAPerformed($state);
 
-        if (AuthSwitcher::SFA === $maxUserCapability) {
-            $state['Attributes'][$this->max_user_capability_attr][] = $this->max_auth;
-        } elseif (AuthSwitcher::MFA === $maxUserCapability && $mfaPerformed) {
+        if (AuthSwitcher::SFA === $maxUserCapability || (AuthSwitcher::MFA === $maxUserCapability && $mfaPerformed)) {
             $state['Attributes'][$this->max_user_capability_attr][] = $this->max_auth;
         }
 
-        $possibleReplies = $mfaPerformed ? AuthSwitcher::REPLY_CONTEXTS_MFA : AuthSwitcher::REPLY_CONTEXTS_SFA;
+        $possibleReplies = $mfaPerformed ? array_merge(
+            AuthSwitcher::REPLY_CONTEXTS_MFA,
+            AuthSwitcher::REPLY_CONTEXTS_SFA
+        ) : AuthSwitcher::REPLY_CONTEXTS_SFA;
         $possibleReplies = array_values(
             array_intersect($possibleReplies, $state[AuthSwitcher::SUPPORTED_REQUESTED_CONTEXTS])
         );
@@ -240,9 +248,7 @@ class SwitchAuth extends \SimpleSAML\Auth\ProcessingFilter
                 }
             }
         }
-        if (empty($state['Attributes']['mfaEnforced']) || empty($result)) {
-            $result[] = AuthSwitcher::SFA;
-        }
+        $result[] = AuthSwitcher::SFA;
 
         return $result;
     }


### PR DESCRIPTION
* allow enforced MFA even when only password is requested (it is expected that password is a part of MFA, therefore password/SFA may be asserted when doing MFA)
* do not enforce MFA if already done in proxy mode (previously MFA was enforced even if already done)